### PR TITLE
Rollback nodejs to 20.5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: volta-cli/action@v3
+        with:
+          registry-url: https://registry.npmjs.org
+      - name: Install Dependencies
+        run: yarn
+      - name: Check types
+        run: yarn check:types
+      - name: Lint
+        run: yarn lint
+      - name: Test
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "CHANGELOG.md"
   ],
   "volta": {
-    "node": "20.6.1",
+    "node": "20.5.1",
     "yarn": "3.6.3"
   },
   "lint-staged": {


### PR DESCRIPTION
## Motivation

For some reason `pack` script fails with node 20.6.1

## Approach

Rolled back to 20.5.1