### PR TITLE
Remove `Connection` interface

### DIFF
--- a/.changeset/thick-pumpkins-tease.md
+++ b/.changeset/thick-pumpkins-tease.md
@@ -1,0 +1,5 @@
+---
+"@frontside/hydraphql": patch
+---
+
+Remove `Connection` interface

--- a/src/__snapshots__/schema.graphql.snap
+++ b/src/__snapshots__/schema.graphql.snap
@@ -8,26 +8,8 @@ directive @implements(interface: String!) on INTERFACE | OBJECT
 
 directive @resolve(at: _DirectiveArgument_, from: String) on FIELD_DEFINITION
 
-interface Connection {
-  count: Int
-  edges: [Edge!]!
-  pageInfo: PageInfo!
-}
-
-interface Edge {
-  cursor: String!
-  node: Node!
-}
-
 interface Node {
   id: ID!
-}
-
-type PageInfo {
-  endCursor: String
-  hasNextPage: Boolean!
-  hasPreviousPage: Boolean!
-  startCursor: String
 }
 
 type Query {

--- a/src/__snapshots__/types.ts.snap
+++ b/src/__snapshots__/types.ts.snap
@@ -19,27 +19,8 @@ export type Scalars = {
   _DirectiveArgument_: { input: any; output: any; }
 };
 
-export type Connection = {
-  count?: Maybe<Scalars['Int']['output']>;
-  edges: Array<Edge>;
-  pageInfo: PageInfo;
-};
-
-export type Edge = {
-  cursor: Scalars['String']['output'];
-  node: Node;
-};
-
 export type Node = {
   id: Scalars['ID']['output'];
-};
-
-export type PageInfo = {
-  __typename?: 'PageInfo';
-  endCursor?: Maybe<Scalars['String']['output']>;
-  hasNextPage: Scalars['Boolean']['output'];
-  hasPreviousPage: Scalars['Boolean']['output'];
-  startCursor?: Maybe<Scalars['String']['output']>;
 };
 
 export type Query = {
@@ -128,20 +109,14 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
-  Connection: never;
-  Edge: never;
   Node: never;
 };
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
-  Connection: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Connection']>;
-  Edge: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Edge']>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
-  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
   Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Node']>;
-  PageInfo: ResolverTypeWrapper<PageInfo>;
   Query: ResolverTypeWrapper<{}>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   _DirectiveArgument_: ResolverTypeWrapper<Scalars['_DirectiveArgument_']['output']>;
@@ -150,12 +125,8 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Boolean: Scalars['Boolean']['output'];
-  Connection: ResolversInterfaceTypes<ResolversParentTypes>['Connection'];
-  Edge: ResolversInterfaceTypes<ResolversParentTypes>['Edge'];
   ID: Scalars['ID']['output'];
-  Int: Scalars['Int']['output'];
   Node: ResolversInterfaceTypes<ResolversParentTypes>['Node'];
-  PageInfo: PageInfo;
   Query: {};
   String: Scalars['String']['output'];
   _DirectiveArgument_: Scalars['_DirectiveArgument_']['output'];
@@ -195,30 +166,9 @@ export type ResolveDirectiveArgs = {
 
 export type ResolveDirectiveResolver<Result, Parent, ContextType = any, Args = ResolveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type ConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Connection'] = ResolversParentTypes['Connection']> = {
-  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
-  count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  edges?: Resolver<Array<ResolversTypes['Edge']>, ParentType, ContextType>;
-  pageInfo?: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
-};
-
-export type EdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Edge'] = ResolversParentTypes['Edge']> = {
-  __resolveType: TypeResolveFn<null, ParentType, ContextType>;
-  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  node?: Resolver<ResolversTypes['Node'], ParentType, ContextType>;
-};
-
 export type NodeResolvers<ContextType = any, ParentType extends ResolversParentTypes['Node'] = ResolversParentTypes['Node']> = {
   __resolveType: TypeResolveFn<null, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-};
-
-export type PageInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['PageInfo'] = ResolversParentTypes['PageInfo']> = {
-  endCursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  hasNextPage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  hasPreviousPage?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  startCursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
@@ -231,10 +181,7 @@ export interface _DirectiveArgument_ScalarConfig extends GraphQLScalarTypeConfig
 }
 
 export type Resolvers<ContextType = any> = {
-  Connection?: ConnectionResolvers<ContextType>;
-  Edge?: EdgeResolvers<ContextType>;
   Node?: NodeResolvers<ContextType>;
-  PageInfo?: PageInfoResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   _DirectiveArgument_?: GraphQLScalarType;
 };

--- a/src/core/core.graphql
+++ b/src/core/core.graphql
@@ -19,24 +19,6 @@ interface Node {
   id: ID!
 }
 
-interface Connection {
-  pageInfo: PageInfo!
-  edges: [Edge!]!
-  count: Int
-}
-
-type PageInfo {
-  hasNextPage: Boolean!
-  hasPreviousPage: Boolean!
-  startCursor: String
-  endCursor: String
-}
-
-interface Edge {
-  cursor: String!
-  node: Node!
-}
-
 type Query {
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!

--- a/src/mapDirectives.test.ts
+++ b/src/mapDirectives.test.ts
@@ -129,15 +129,13 @@ describe("mapDirectives", () => {
 
   void test("should merge fields for basic types", () => {
     const schema = transform(gql`
-      interface Connection {
+      interface Node {
         foobar: String!
       }
     `);
-    expect(printType(schema.getType("Connection")!).split("\n")).toEqual([
-      "interface Connection {",
-      "  pageInfo: PageInfo!",
-      "  edges: [Edge!]!",
-      "  count: Int",
+    expect(printType(schema.getType("Node")!).split("\n")).toEqual([
+      "interface Node {",
+      "  id: ID!",
       "  foobar: String!",
       "}",
     ]);


### PR DESCRIPTION
## Motivation

`Connection` interface is used for `@relation` directive which is not part of this project anymore, because `@relation` directive is related to backstage catalog types

## Approach

Remove unnecessary code which might cause conflicts if used in other projects