### PR TITLE
Improve `@resolve` directive to handle arrays

### DIFF
--- a/.changeset/dry-spiders-draw.md
+++ b/.changeset/dry-spiders-draw.md
@@ -1,0 +1,5 @@
+---
+"@frontside/hydraphql": minor
+---
+
+Improve @resolve directive to handle arrays

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@graphql-tools/merge": "^9.0.0",
     "@graphql-tools/schema": "^10.0.0",
     "@graphql-tools/utils": "^10.0.0",
+    "graphql-relay": "^0.10.0",
     "lodash": "^4.17.21",
     "pascal-case": "^3.1.2",
     "reflect-metadata": "^0.1.13",

--- a/src/__snapshots__/schema.graphql.snap
+++ b/src/__snapshots__/schema.graphql.snap
@@ -2,11 +2,11 @@ directive @discriminates(opaqueType: String, with: _DirectiveArgument_) on INTER
 
 directive @discriminationAlias(type: String!, value: String!) repeatable on INTERFACE
 
-directive @field(at: _DirectiveArgument_!, default: _DirectiveArgument_) on FIELD_DEFINITION
+directive @field(at: _DirectiveArgument_, default: _DirectiveArgument_) on FIELD_DEFINITION
 
 directive @implements(interface: String!) on INTERFACE | OBJECT
 
-directive @resolve(at: _DirectiveArgument_, from: String) on FIELD_DEFINITION
+directive @resolve(at: _DirectiveArgument_, from: String, nodeType: String) on FIELD_DEFINITION
 
 interface Connection {
   count: Int

--- a/src/__snapshots__/types.ts.snap
+++ b/src/__snapshots__/types.ts.snap
@@ -176,7 +176,7 @@ export type DiscriminationAliasDirectiveArgs = {
 export type DiscriminationAliasDirectiveResolver<Result, Parent, ContextType = any, Args = DiscriminationAliasDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type FieldDirectiveArgs = {
-  at: Scalars['_DirectiveArgument_']['input'];
+  at?: Maybe<Scalars['_DirectiveArgument_']['input']>;
   default?: Maybe<Scalars['_DirectiveArgument_']['input']>;
 };
 
@@ -191,6 +191,7 @@ export type ImplementsDirectiveResolver<Result, Parent, ContextType = any, Args 
 export type ResolveDirectiveArgs = {
   at?: Maybe<Scalars['_DirectiveArgument_']['input']>;
   from?: Maybe<Scalars['String']['input']>;
+  nodeType?: Maybe<Scalars['String']['input']>;
 };
 
 export type ResolveDirectiveResolver<Result, Parent, ContextType = any, Args = ResolveDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;

--- a/src/core/core.graphql
+++ b/src/core/core.graphql
@@ -1,5 +1,5 @@
 directive @field(
-  at: _DirectiveArgument_!
+  at: _DirectiveArgument_
   default: _DirectiveArgument_
 ) on FIELD_DEFINITION
 directive @discriminates(
@@ -11,7 +11,7 @@ directive @discriminationAlias(
   type: String!
 ) repeatable on INTERFACE
 directive @implements(interface: String!) on OBJECT | INTERFACE
-directive @resolve(at: _DirectiveArgument_, from: String) on FIELD_DEFINITION
+directive @resolve(at: _DirectiveArgument_, nodeType: String, from: String) on FIELD_DEFINITION
 
 scalar _DirectiveArgument_
 

--- a/src/core/fieldDirectiveMapper.ts
+++ b/src/core/fieldDirectiveMapper.ts
@@ -4,7 +4,7 @@ import type { ResolverContext } from "../types.js";
 import { id } from "../helpers.js";
 
 export function fieldDirectiveMapper(
-  _fieldName: string,
+  fieldName: string,
   field: GraphQLFieldConfig<
     { id: string },
     ResolverContext,
@@ -34,8 +34,10 @@ export function fieldDirectiveMapper(
     const entity = await loader.load(id);
     if (!entity) return null;
     const source =
-      (_.get(entity, directive.at as string | string[]) as unknown) ??
-      directive.default;
+      (_.get(
+        entity,
+        (directive.at as undefined | string | string[]) ?? fieldName,
+      ) as unknown) ?? directive.default;
     return fieldResolve(source, args, context, info);
   };
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,16 @@
-import { isListType, isNonNullType } from "graphql";
+import {
+  isInterfaceType,
+  isListType,
+  isNonNullType,
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLList,
+  isInputType,
+  isUnionType,
+  GraphQLID,
+  GraphQLInterfaceType,
+  isObjectType,
+} from "graphql";
 import type { GraphQLNamedType, GraphQLOutputType } from "graphql";
 import type { NodeId, NodeQuery } from "./types.js";
 
@@ -26,6 +38,114 @@ export function unboxNamedType(type: GraphQLOutputType): GraphQLNamedType {
     return unboxNamedType(type.ofType);
   }
   return type;
+}
+
+export function isNamedListType(type: GraphQLOutputType): boolean {
+  if (isNonNullType(type)) {
+    return isListType(type.ofType);
+  }
+  return isListType(type);
+}
+
+export function isConnectionType(type: unknown): type is GraphQLInterfaceType {
+  return (
+    (isInterfaceType(type) && type.name === "Connection") ||
+    (isNonNullType(type) && isConnectionType(type.ofType))
+  );
+}
+
+export function createConnectionType(
+  nodeType: GraphQLInterfaceType | GraphQLObjectType,
+  fieldType: GraphQLInterfaceType,
+): GraphQLObjectType {
+  const wrappedEdgeType = fieldType.getFields().edges.type as GraphQLNonNull<
+    GraphQLList<GraphQLNonNull<GraphQLInterfaceType>>
+  >;
+  const edgeType = wrappedEdgeType.ofType.ofType.ofType;
+
+  return new GraphQLObjectType({
+    name: `${nodeType.name}Connection`,
+    fields: {
+      ...fieldType.toConfig().fields,
+      edges: {
+        type: new GraphQLNonNull(
+          new GraphQLList(
+            new GraphQLNonNull(
+              new GraphQLObjectType({
+                name: `${nodeType.name}Edge`,
+                fields: {
+                  ...edgeType.toConfig().fields,
+                  node: {
+                    type: new GraphQLNonNull(nodeType),
+                  },
+                },
+                interfaces: [edgeType],
+              }),
+            ),
+          ),
+        ),
+      },
+    },
+    interfaces: [fieldType],
+  });
+}
+
+export function getNoteTypeForConnection(
+  typeName: string,
+  getType: (name: string) => GraphQLNamedType | undefined,
+  setType: (name: string, type: GraphQLNamedType) => void,
+): GraphQLInterfaceType | GraphQLObjectType {
+  const nodeType = getType(typeName);
+
+  if (!nodeType) {
+    throw new Error(`The interface "${typeName}" is not defined in the schema`);
+  }
+  if (isInputType(nodeType)) {
+    throw new Error(
+      `The interface "${typeName}" is an input type and can't be used in a Connection`,
+    );
+  }
+  if (isUnionType(nodeType)) {
+    const resolveType = nodeType.resolveType;
+    if (resolveType)
+      throw new Error(
+        `The "resolveType" function has already been implemented for "${nodeType.name}" union which may lead to undefined behavior`,
+      );
+    const iface = new GraphQLInterfaceType({
+      name: typeName,
+      interfaces: [getType("Node") as GraphQLInterfaceType],
+      fields: { id: { type: new GraphQLNonNull(GraphQLID) } },
+      resolveType: (...args) =>
+        (getType("Node") as GraphQLInterfaceType).resolveType?.(...args),
+    });
+    setType(typeName, iface);
+    nodeType
+      .getTypes()
+      .map((type) => getType(type.name))
+      .forEach((type) => {
+        if (isInterfaceType(type)) {
+          setType(
+            type.name,
+            new GraphQLInterfaceType({
+              ...type.toConfig(),
+              interfaces: [...type.getInterfaces(), iface],
+            }),
+          );
+        }
+        if (isObjectType(type)) {
+          setType(
+            type.name,
+            new GraphQLObjectType({
+              ...type.toConfig(),
+              interfaces: [...type.getInterfaces(), iface],
+            }),
+          );
+        }
+      });
+    return iface;
+  } else {
+    return nodeType;
+  }
 }
 
 function isNodeQuery(obj: unknown): obj is NodeQuery {

--- a/src/mapCompositeField.ts
+++ b/src/mapCompositeField.ts
@@ -43,7 +43,10 @@ export function mapCompositeFields<
         ResolverContext,
         Record<string, unknown> | undefined
       >;
-      mapper(fieldName, config, directive, api);
+      mapper(fieldName, config, directive, {
+        ...api,
+        typeName: typeConfig.name,
+      });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : error;
       throw new Error(

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export type FieldDirectiveMapper = (
     Record<string, unknown> | undefined
   >,
   directive: Record<string, unknown>,
-  api: DirectiveMapperAPI,
+  api: DirectiveMapperAPI & { typeName: string },
 ) => void;
 
 export interface NamedType {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,6 +1236,7 @@ __metadata:
     expect: ^29.6.4
     graphql: ^16.6.0
     graphql-modules: ^2.2.0
+    graphql-relay: ^0.10.0
     husky: ^8.0.0
     lint-staged: ^14.0.1
     lodash: ^4.17.21
@@ -4460,6 +4461,15 @@ __metadata:
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
   checksum: dac754ea72ef0aedd5ed276742ca13b7f0a9290f3747fcdc33b01582044a495eab9184feb452a316985a011f68b69a3172b4ea5dd582807f0c1430deee94f63b
+  languageName: node
+  linkType: hard
+
+"graphql-relay@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "graphql-relay@npm:0.10.0"
+  peerDependencies:
+    graphql: ^16.2.0
+  checksum: 74b2b608ed7c18cc405d53fa7e482a68442a4dc7c0748bba029c59e1d23c6c6e5b8193c775eb73f6bb0dce49501f66af0453eb0b0f0362374cef9f97528852c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Motivation

Currently `@resolve` directive can handle only string values, but if field contains an array of strings it's impossible to use `@resolve` for it

## Approach

Add ability to handle arrays of strings by `@resolve` directive and resolve them to either array of items of a `Connection`

