### PR TITLE
Fix helper name typos

### DIFF
--- a/.changeset/lovely-news-search.md
+++ b/.changeset/lovely-news-search.md
@@ -1,0 +1,5 @@
+---
+"@frontside/hydraphql": patch
+---
+
+Fix helper name typos

--- a/src/core/resolveDirectiveMapper.ts
+++ b/src/core/resolveDirectiveMapper.ts
@@ -12,7 +12,7 @@ import {
   createConnectionType,
   decodeId,
   encodeId,
-  getNoteTypeForConnection,
+  getNodeTypeForConnection,
   isConnectionType,
   isNamedListType,
   unboxNamedType,
@@ -41,7 +41,7 @@ export function resolveDirectiveMapper(
 
   if (isConnectionType(field.type)) {
     if (directive.nodeType && typeof directive.nodeType === "string") {
-      const nodeType = getNoteTypeForConnection(
+      const nodeType = getNodeTypeForConnection(
         directive.nodeType,
         (name) => api.typeMap[name],
         (name, type) => (api.typeMap[name] = type),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -87,7 +87,7 @@ export function createConnectionType(
   });
 }
 
-export function getNoteTypeForConnection(
+export function getNodeTypeForConnection(
   typeName: string,
   getType: (name: string) => GraphQLNamedType | undefined,
   setType: (name: string, type: GraphQLNamedType) => void,


### PR DESCRIPTION
## Motivation

A helper function has typos in it's name

## Approach

Rename `getNoteTypeForConnection` to `getNodeTypeForConnection`
