### PR TITLE
Re-export GraphQLModule interface

### DIFF
--- a/.changeset/eight-buses-do.md
+++ b/.changeset/eight-buses-do.md
@@ -1,0 +1,5 @@
+---
+"@frontside/hydraphql": patch
+---
+
+Re-export GraphQLModule interface

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,5 @@ export type {
   OmitFirst,
   NodeQuery,
   NodeId,
+  GraphQLModule,
 } from "./types.js";


### PR DESCRIPTION
## Motivation

`GraphQLModule` isn't exported out package

## Approach

Export the `GraphQLModule` interface
