### PR TITLE
Add postTransform option to allow apply custom transformations after schema mapping

### DIFF
--- a/.changeset/sixty-walls-guess.md
+++ b/.changeset/sixty-walls-guess.md
@@ -1,0 +1,5 @@
+---
+"@frontside/hydraphql": patch
+---
+
+Add postTransform option to allow apply custom transformations after schema mapping

--- a/src/__testUtils__/createApi.ts
+++ b/src/__testUtils__/createApi.ts
@@ -6,17 +6,18 @@ import { useDataLoader } from "@envelop/dataloader";
 import { useGraphQLModules } from "@envelop/graphql-modules";
 import { createGraphQLApp } from "../createGraphQLApp.js";
 import type { GraphQLContext, GraphQLModule } from "../types.js";
+import { TransformSchemaOptions } from "src/transformSchema.js";
 
 export async function createGraphQLAPI(
   TestModule: GraphQLModule | Module,
   loader: (
     context: Record<string, unknown> & GraphQLContext,
   ) => DataLoader<string, unknown>,
-  generateOpaqueTypes?: boolean,
+  options: TransformSchemaOptions = {},
 ) {
   const application = await createGraphQLApp({
     modules: [TestModule],
-    generateOpaqueTypes,
+    ...options,
   });
 
   const run = envelop({

--- a/src/createGraphQLApp.ts
+++ b/src/createGraphQLApp.ts
@@ -1,13 +1,12 @@
 import { createApplication } from "graphql-modules";
 import type { Module } from "graphql-modules";
-import { transformSchema } from "./transformSchema.js";
+import { TransformSchemaOptions, transformSchema } from "./transformSchema.js";
 import { loadSchema } from "./loadSchema.js";
 import { GraphQLModule } from "./types.js";
 
-export interface createGraphQLAppOptions {
+export interface createGraphQLAppOptions extends TransformSchemaOptions {
   schema?: string | string[];
   modules?: (GraphQLModule | Module)[];
-  generateOpaqueTypes?: boolean;
 }
 
 export async function createGraphQLApp(options: createGraphQLAppOptions) {
@@ -17,6 +16,7 @@ export async function createGraphQLApp(options: createGraphQLAppOptions) {
   }
   const schema = transformSchema(modules, {
     generateOpaqueTypes: options.generateOpaqueTypes,
+    postTransform: options.postTransform,
   });
   return createApplication({
     schemaBuilder: () => schema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./createGraphQLApp.js";
 export * from "./core/core.js";
 export * from "./helpers.js";
 export { transformSchema } from "./transformSchema.js";
+export type { TransformSchemaOptions } from "./transformSchema.js";
 export type {
   GraphQLContext,
   ResolverContext,

--- a/src/mapDirectives.test.ts
+++ b/src/mapDirectives.test.ts
@@ -1256,7 +1256,9 @@ describe("mapDirectives", () => {
             }),
           ),
       );
-    const query = await createGraphQLAPI(TestModule, loader, true);
+    const query = await createGraphQLAPI(TestModule, loader, {
+      generateOpaqueTypes: true,
+    });
     const queryNode = (id: NodeId) =>
       query(/* GraphQL */ `
         node(id: ${JSON.stringify(encodeId(id))}) {


### PR DESCRIPTION
## Motivation

Backstage GraphQL Plugin requires to walkthrough post transformed schema to collect `@field` directives mapping and generate entities filter input type(-s)

## Approach

Expose `postTransform` option

### Alternate Designs

Utilize `graphql-codegen` API and probably separate transformations as codegen plugins