### PR TITLE
Add postTransform option to allow apply custom transformations after schema mapping

### DIFF
--- a/.changeset/clean-badgers-tie.md
+++ b/.changeset/clean-badgers-tie.md
@@ -1,0 +1,5 @@
+---
+"@frontside/hydraphql": patch
+---
+
+Add postTransform option to allow apply custom transformations after schema mapping

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import type {
   GraphQLFieldConfig,
   GraphQLNamedType,
   GraphQLObjectType,
+  GraphQLSchema,
 } from "graphql";
 import type { Application, Module } from "graphql-modules";
 
@@ -64,5 +65,6 @@ export interface NamedType {
 
 export interface GraphQLModule {
   mappers?: Record<string, FieldDirectiveMapper>;
+  postTransform?: (schema: GraphQLSchema) => GraphQLSchema;
   module: Module;
 }


### PR DESCRIPTION
## Motivation

Backstage GraphQL Plugin requires to generate an input type for `entities` query filter argument according to `@field` directives

## Approach

I decided that it might be good idea to define post schema transformations on GraphQL modules' level and apply in the same order as schema merged. It also allows us to define schema transformations and don't overwhelm end user asking them to apply additional transformations to a schema.
