### PR TITLE
Add GraphQL field extension with field resolver function

### DIFF
--- a/.changeset/unlucky-deers-shop.md
+++ b/.changeset/unlucky-deers-shop.md
@@ -1,0 +1,5 @@
+---
+"@frontside/hydraphql": patch
+---
+
+Add GraphQL field extension with field resolver function

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const HYDRAPHQL_EXTENSION = "@frontside/hydraphql";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,4 +13,7 @@ export type {
   NodeQuery,
   NodeId,
   GraphQLModule,
+  FieldResolver,
+  FieldExtensions,
 } from "./types.js";
+export * from "./constants.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,3 +68,15 @@ export interface GraphQLModule {
   postTransform?: (schema: GraphQLSchema) => GraphQLSchema;
   module: Module;
 }
+
+export type FieldResolver<T = { id: string; entity: unknown }> = NonNullable<
+  GraphQLFieldConfig<
+    T,
+    ResolverContext,
+    Record<string, unknown> | undefined
+  >["resolve"]
+>;
+
+export interface FieldExtensions {
+  fieldResolver: FieldResolver;
+}


### PR DESCRIPTION
## Motivation

In Backstage GraphQL plugin we query Catalog API to get entities that matched to specific filter, then we have to resolve each entity to GraphQL Node, but in our fields' resolvers we call data loader to fetch entity (again) and get field's value. We could improve and get rid of unnecessary `getEntitiesByRefs` call if we are able resolve fields right away.

## Approach

Utilize GraphQL Extensions to store field's resolver, that accepts `{ id, entity }` node's id and source object and returns needed field's value
